### PR TITLE
chore: promote react2 to version 0.0.5

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -3,5 +3,6 @@ helmfiles:
 - path: helmfiles/jx/helmfile.yaml
 - path: helmfiles/secret-infra/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
+- path: helmfiles/jx-staging/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -1,0 +1,11 @@
+filepath: ""
+namespace: jx-staging
+repositories:
+- name: dev
+  url: https://hazem-internship.github.io/react2/
+releases:
+- chart: dev/react2
+  version: 0.0.5
+  name: react2
+templates: {}
+renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react2

## Changes in version 0.0.5

### Chores

* release 0.0.5 (jenkins-x-bot)
* add variables (jenkins-x-bot)
