### PR TITLE
chore: promote react2 to version 0.0.6

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
   url: https://hazem-internship.github.io/react2/
 releases:
 - chart: dev/react2
-  version: 0.0.5
+  version: 0.0.6
   name: react2
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react2

## Changes in version 0.0.6

### Chores

* release 0.0.6 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Update Chart.yaml (hazemtahri)
