### PR TITLE
chore: promote react2 to version 0.0.7

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -3,9 +3,11 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: https://hazem-internship.github.io/react2/
+- name: dev2
+  url: https://hazem-internship.github.io/k8s-1/
 releases:
 - chart: dev/react2
-  version: 0.0.5
+  version: 0.0.7
   name: react2
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react2

## Changes in version 0.0.7

### Chores

* release 0.0.7 (jenkins-x-bot)
* add variables (jenkins-x-bot)
